### PR TITLE
Refactor permission and role selection hooks, and clean up S3 utility…

### DIFF
--- a/app/(protected)/user-management/permissions/hooks/use-permission-select-query.js
+++ b/app/(protected)/user-management/permissions/hooks/use-permission-select-query.js
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { useToast } from '@/providers/toast-provider';
 import { apiFetch } from '@/lib/api';
+import { toastError } from '@/providers/toast-provider';
 
 // Custom hook to use roles for selection
 export const usePermissionSelectQuery = () => {

--- a/app/(protected)/user-management/roles/hooks/use-role-select-query.js
+++ b/app/(protected)/user-management/roles/hooks/use-role-select-query.js
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { useToast } from '@/providers/toast-provider';
 import { apiFetch } from '@/lib/api';
+import { toastError } from '@/providers/toast-provider';
 
 // Custom hook to use roles for selection
 export const useRoleSelectQuery = () => {

--- a/app/api/events/[id]/route.js
+++ b/app/api/events/[id]/route.js
@@ -1,42 +1,20 @@
 import { NextResponse } from 'next/server';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { PrismaClient } from '@prisma/client';
-import { getServerSession } from 'next-auth';
 import { checkEventManagementAccess } from '@/lib/auth-utils';
 import { uid } from '@/lib/helpers';
 import {
   createS3Client,
   deleteImageFromS3,
   generateDirectS3Url,
-  getS3Config,
 } from '@/lib/s3-utils';
 import { sendBulkEventInvitations } from '@/services/send-event-invitation.js';
-import authOptions from '@/app/api/auth/[...nextauth]/auth-options';
 
 const prisma = new PrismaClient();
 
-// Create S3 client function
-function createS3Client() {
-  const { region, endpoint } = getS3Config();
 
-  const config = {
-    region,
-    credentials: {
-      accessKeyId:
-        process.env.AWS_ACCESS_KEY_ID || process.env.STORAGE_ACCESS_KEY_ID,
-      secretAccessKey:
-        process.env.AWS_SECRET_ACCESS_KEY ||
-        process.env.STORAGE_SECRET_ACCESS_KEY,
-    },
-  };
 
-  if (endpoint) {
-    config.endpoint = endpoint;
-    config.forcePathStyle = true;
-  }
 
-  return new S3Client(config);
-}
 
 // GET /api/events/[id] - Get a specific event (public access for design pages)
 export async function GET(request, { params }) {

--- a/app/api/template/[id]/save-image/route.js
+++ b/app/api/template/[id]/save-image/route.js
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { PrismaClient } from '@prisma/client';
 import { getServerSession } from 'next-auth';
-import { createS3Client, generateProxyUrl, getS3Config } from '@/lib/s3-utils';
+import { createS3Client, generateProxyUrl } from '@/lib/s3-utils';
 import authOptions from '../../../auth/[...nextauth]/auth-options';
 
 // Helper function to check if user has admin role

--- a/app/api/template/[id]/update-image/route.js
+++ b/app/api/template/[id]/update-image/route.js
@@ -7,7 +7,7 @@ import {
 import { PrismaClient } from '@prisma/client';
 import { getServerSession } from 'next-auth';
 import { uid } from '@/lib/helpers';
-import { createS3Client, generateProxyUrl, getS3Config } from '@/lib/s3-utils';
+import { createS3Client, generateProxyUrl } from '@/lib/s3-utils';
 import authOptions from '../../../auth/[...nextauth]/auth-options';
 
 // Helper function to check if user has admin role

--- a/app/api/template/[id]/upload-thumbnail/route.js
+++ b/app/api/template/[id]/upload-thumbnail/route.js
@@ -80,7 +80,7 @@ export async function POST(request, { params }) {
 
     // Upload to S3
     const s3Client = createS3Client();
-    const { bucket, region, endpoint } = getS3Config();
+    const { bucket } = getS3Config();
 
     if (!bucket) {
       return NextResponse.json(


### PR DESCRIPTION
… imports

- Updated `usePermissionSelectQuery` and `useRoleSelectQuery` hooks to import `toastError` instead of `useToast`.
- Removed unused `getS3Config` import from event and template image routes, streamlining S3 client creation.
- Adjusted S3 upload logic to only retrieve necessary configuration values.